### PR TITLE
Fix backend error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 node_modules
 lib
+
+## IntelliJ
+*.iml
+.idea/

--- a/README.md
+++ b/README.md
@@ -295,3 +295,21 @@ We're considering adapting this input to support any type of nest-able data, not
 ## License
 
 MIT-licensed. See LICENSE.
+
+## Developing
+
+If you want to test a dev-build of this plugin in the studio there is a bit of a workaround.
+npm/yarn link does not integrate correctly with StructureBuilder and schema part registration in
+the Studio.
+
+The most consistent workflow is:
+
+1.Install [yalc](https://github.com/wclr/yalc)
+2. Run `npm run build && yalc publish` in this repo
+3. In Sanity Studio:
+   1. Run `yalc link @sanity/hierarchical-document-list`
+   2. Run `yarn install` (installs the dependencies for the plugin)
+   3. Ensure `"@sanity/hierarchical-document-list"` is present in `sanity.json` plugins array.
+   4. Configure the plugin for structure as documented above
+
+Rerun steps 2. and 3.1 after making edits to the plugin (or automate it).

--- a/package-lock.json
+++ b/package-lock.json
@@ -4220,7 +4220,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -4288,7 +4287,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -4723,7 +4721,6 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -6053,7 +6050,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@sanity/icons/-/icons-1.2.3.tgz",
       "integrity": "sha512-yp/o9Kd/4gEncihLrly/PNXo77Z6+xHkEZP4K2/C+PJ7/dXR7Nyy4Lj729tR/0SQKA/Rc8WEapGQCPmWVBvHOQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@sanity/image-url": {
       "version": "1.0.1",
@@ -6630,7 +6628,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv": {
       "version": "6.12.6",
@@ -7220,13 +7219,15 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-sanity": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-sanity/-/eslint-config-sanity-5.1.0.tgz",
       "integrity": "sha512-kYd4Euy33hDoFxAgLIGtFGm9TB7YpIY5c+atyCESDRh+WnadxhlYSrrJvAUne84CWPZxybe5f4U+m9K+uc/eeQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -8334,7 +8335,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/observable-callback/-/observable-callback-1.0.1.tgz",
       "integrity": "sha512-lgehuL4SP5DHEHNV/MZNhlTSeGV/xbX/l90H1FcCWm9b9yac/NKk9FnaTOt36wW3+EUvJSQjezDFKpi5hi8EHg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "once": {
       "version": "1.4.0",
@@ -8475,7 +8477,8 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/popper-max-size-modifier/-/popper-max-size-modifier-0.2.0.tgz",
       "integrity": "sha512-UerPt9pZfTFnpSpIBVJrR3ibHMuU1k5K01AyNLfMUWCr4z1MFH+dsayPlAF9ZeYExa02HPiQn5OIMqUSVtJEbg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "postcss-value-parser": {
       "version": "4.2.0",
@@ -8594,7 +8597,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -8654,7 +8656,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -8685,13 +8686,15 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/react-icon-base/-/react-icon-base-2.1.2.tgz",
       "integrity": "sha512-NRlRo0RPxWRMQT7osj8UCBSSXsGOxhF1pre84ildhuft5S2U382NOs7tg29osWSjbO90L2a3VTCqadA/LnAzHQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react-intersection-observer": {
       "version": "8.33.1",
       "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-8.33.1.tgz",
       "integrity": "sha512-3v+qaJvp3D1MlGHyM+KISVg/CMhPiOlO6FgPHcluqHkx4YFCLuyXNlQ/LE6UkbODXlQcLOppfX6UMxCEkUhDLw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",
@@ -8745,7 +8748,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/react-props-stream/-/react-props-stream-1.0.1.tgz",
       "integrity": "sha512-lBMW9S7OvqE8sYruPTpG8Dv7WVwHiDt4hJmhixoRNlHBtVMnMvMJal/tsH8F/YKMsObvSkY3PCWCPRLqnEaOaw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react-refractor": {
       "version": "2.1.5",
@@ -8960,7 +8964,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/rxjs-exhaustmap-with-trailing/-/rxjs-exhaustmap-with-trailing-1.1.0.tgz",
       "integrity": "sha512-ZCqM4sj/+vt20n+EEImDIQurrQ0zc/m237T6wL5C4cgRArAHtnpdeMCmjXd/rogvz8Ak1G1V6g2t48t1OB2V4A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "safe-buffer": {
       "version": "5.1.2",
@@ -8986,7 +8991,6 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
       "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -9357,13 +9361,15 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.5.tgz",
       "integrity": "sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "use-device-pixel-ratio": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/use-device-pixel-ratio/-/use-device-pixel-ratio-1.1.0.tgz",
       "integrity": "sha512-1c8CNimTFp8V1prGF5yLJ1WA+WGCqXlONaeQaOS2QgV7pFbJlsSYcNaxlisRcUkjZHiPI8seSRK1wY73OziGqg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "use-sidecar": {
       "version": "1.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2655,9 +2655,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "dev": true,
       "funding": [
         {
@@ -4115,10 +4115,13 @@
       }
     },
     "node_modules/prismjs": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.25.0.tgz",
-      "integrity": "sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg==",
-      "dev": true
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -4555,14 +4558,14 @@
       }
     },
     "node_modules/refractor": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.5.0.tgz",
-      "integrity": "sha512-QwPJd3ferTZ4cSPPjdP5bsYHMytwWYnAN5EEnLtGvkqp/FCCnGsBgxrm9EuIDnjUC3Uc/kETtvVi7fSIVC74Dg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
+      "integrity": "sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==",
       "dev": true,
       "dependencies": {
         "hastscript": "^6.0.0",
         "parse-entities": "^2.0.0",
-        "prismjs": "~1.25.0"
+        "prismjs": "~1.27.0"
       },
       "funding": {
         "type": "github",
@@ -5197,9 +5200,9 @@
       }
     },
     "node_modules/url-parse": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.4.tgz",
-      "integrity": "sha512-ITeAByWWoqutFClc/lRZnFplgXgEZr3WJ6XngMM/N9DMIm4K8zXPCZ1Jdu0rERwO84w1WC5wkle2ubwTA4NTBg==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "dev": true,
       "dependencies": {
         "querystringify": "^2.1.1",
@@ -7429,9 +7432,9 @@
       }
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "dev": true
     },
     "foreach": {
@@ -8514,9 +8517,9 @@
       }
     },
     "prismjs": {
-      "version": "1.25.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.25.0.tgz",
-      "integrity": "sha512-WCjJHl1KEWbnkQom1+SzftbtXMKQoezOCYs5rECqMN+jP+apI7ftoflyqigqzopSO3hMhTEb0mFClA8lkolgEg==",
+      "version": "1.27.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.27.0.tgz",
+      "integrity": "sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==",
       "dev": true
     },
     "process": {
@@ -8871,14 +8874,14 @@
       }
     },
     "refractor": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.5.0.tgz",
-      "integrity": "sha512-QwPJd3ferTZ4cSPPjdP5bsYHMytwWYnAN5EEnLtGvkqp/FCCnGsBgxrm9EuIDnjUC3Uc/kETtvVi7fSIVC74Dg==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/refractor/-/refractor-3.6.0.tgz",
+      "integrity": "sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==",
       "dev": true,
       "requires": {
         "hastscript": "^6.0.0",
         "parse-entities": "^2.0.0",
-        "prismjs": "~1.25.0"
+        "prismjs": "~1.27.0"
       }
     },
     "regenerator-runtime": {
@@ -9348,9 +9351,9 @@
       }
     },
     "url-parse": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.4.tgz",
-      "integrity": "sha512-ITeAByWWoqutFClc/lRZnFplgXgEZr3WJ6XngMM/N9DMIm4K8zXPCZ1Jdu0rERwO84w1WC5wkle2ubwTA4NTBg==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
       "dev": true,
       "requires": {
         "querystringify": "^2.1.1",

--- a/src/TreeInputComponent.tsx
+++ b/src/TreeInputComponent.tsx
@@ -38,7 +38,6 @@ const TreeInputComponent: React.FC<TreeInputComponentProps> = React.forwardRef((
       title={props.type.title} // Creates label from schema title
       __unstable_markers={props.markers} // Handles all markers including validation
       __unstable_presence={props.presence} // Handles presence avatars
-      // @ts-expect-error FormField's TS definitions are off - it doesn't include compareValue
       compareValue={props.compareValue} // Handles "edited" status
     >
       <TreeEditor options={props.type.options} tree={props.value || []} onChange={onChange} />

--- a/src/components/SuppressedDnDManager.tsx
+++ b/src/components/SuppressedDnDManager.tsx
@@ -1,0 +1,59 @@
+import {createDndContext} from 'react-dnd'
+import {HTML5Backend} from 'react-dnd-html5-backend'
+import {DragDropManager} from 'dnd-core'
+import {DragDropMonitor, Identifier} from 'dnd-core/lib/interfaces'
+
+/**
+ * Fix lifted from https://github.com/frontend-collective/react-sortable-tree/issues/510#issuecomment-731233436
+ * This DND context is used to resolve errors: "Error: Cannot have two HTML5 backends at the same time."
+ */
+const DnDContext = createDndContext(HTML5Backend)
+const manager = DnDContext.dragDropManager as DragDropManager
+const monitor = manager.getMonitor()
+
+/**
+ * The suppressing monitor (and manager that uses it),
+ * is an additional workaround to prevent non-functional errors in react-dnd from
+ * bubbling to the Sanity error handler (which will emit a toast that can be ignored by the user anyway).
+ */
+const suppressedMonitor: DragDropMonitor = {
+  canDragSource: monitor.canDragSource.bind(monitor),
+  canDropOnTarget(targetId: Identifier | undefined): boolean {
+    try {
+      return monitor.canDropOnTarget(targetId)
+    } catch (e) {
+      // suppress error
+      return false
+    }
+  },
+  didDrop: monitor.didDrop.bind(monitor),
+  getClientOffset: monitor.getClientOffset.bind(monitor),
+  getDifferenceFromInitialOffset: monitor.getDifferenceFromInitialOffset.bind(monitor),
+  getDropResult: monitor.getDropResult.bind(monitor),
+  getInitialClientOffset: monitor.getInitialClientOffset.bind(monitor),
+  getInitialSourceClientOffset: monitor.getInitialSourceClientOffset.bind(monitor),
+  getItem() {
+    // return empty instead of undefined to work around property access failing
+    return monitor.getItem() ?? {}
+  },
+  getItemType: monitor.getItemType.bind(monitor),
+  getSourceClientOffset: monitor.getSourceClientOffset.bind(monitor),
+  getSourceId: monitor.getSourceId.bind(monitor),
+  getTargetIds: monitor.getTargetIds.bind(monitor),
+  isDragging: monitor.isDragging.bind(monitor),
+  isDraggingSource: monitor.isDraggingSource.bind(monitor),
+  isOverTarget: monitor.isOverTarget.bind(monitor),
+  isSourcePublic: monitor.isSourcePublic.bind(monitor),
+  subscribeToOffsetChange: monitor.subscribeToOffsetChange.bind(monitor),
+  subscribeToStateChange: monitor.subscribeToStateChange.bind(monitor)
+}
+
+export const suppressedDnDManager: DragDropManager = {
+  getMonitor() {
+    return suppressedMonitor
+  },
+  getBackend: manager.getBackend.bind(manager),
+  getRegistry: manager.getRegistry.bind(manager),
+  getActions: manager.getActions.bind(manager),
+  dispatch: manager.dispatch.bind(manager)
+}

--- a/src/components/TreeEditor.tsx
+++ b/src/components/TreeEditor.tsx
@@ -44,16 +44,12 @@ const TreeEditor: React.FC<{
     localTree
   })
 
-  const doNothingOnChange = useCallback(() => {
-    // Do nothing. onMoveNode will do all the work
-  }, [])
-
-  const canDrop = useCanDrop()
   const onMoveNode = useCallback(
     (data: NodeData & FullTree & OnMovePreviousAndNextLocation) =>
       operations.handleMovedNode(data as unknown as HandleMovedNodeData),
     [operations]
   )
+
   const treeProps = useMemo(
     () =>
       getCommonTreeProps({
@@ -64,10 +60,15 @@ const TreeEditor: React.FC<{
     []
   )
 
+  const operationContext = useMemo(
+    () => ({...operations, allItemsStatus}),
+    [operations, allItemsStatus]
+  )
+
   return (
     <TreeEditorErrorBoundary>
       <DndProvider manager={suppressedDnDManager}>
-        <TreeOperationsContext.Provider value={{...operations, allItemsStatus}}>
+        <TreeOperationsContext.Provider value={operationContext}>
           <Stack space={4} paddingTop={4}>
             <Card
               style={{minHeight: getTreeHeight(localTree)}}
@@ -142,13 +143,15 @@ const TreeEditor: React.FC<{
   )
 }
 
-function useCanDrop() {
-  return useCallback(({nextPath, prevPath}: OnDragPreviousAndNextLocation & NodeData) => {
-    const insideItself =
-      nextPath.length >= prevPath.length &&
-      prevPath.every((pathIndex, index) => nextPath[index] === pathIndex)
-    return !insideItself
-  }, [])
+function canDrop({nextPath, prevPath}: OnDragPreviousAndNextLocation & NodeData) {
+  const insideItself =
+    nextPath.length >= prevPath.length &&
+    prevPath.every((pathIndex, index) => nextPath[index] === pathIndex)
+  return !insideItself
+}
+
+const doNothingOnChange = () => {
+  // Do nothing. onMoveNode will do all the work
 }
 
 export default TreeEditor

--- a/src/components/TreeEditor.tsx
+++ b/src/components/TreeEditor.tsx
@@ -1,7 +1,14 @@
 import {AddCircleIcon} from '@sanity/icons'
 import {Box, Button, Card, Flex, Spinner, Stack, Text, Tooltip} from '@sanity/ui'
 import * as React from 'react'
-import SortableTree from 'react-sortable-tree'
+import {useCallback, useMemo} from 'react'
+import {
+  FullTree,
+  NodeData,
+  OnDragPreviousAndNextLocation,
+  OnMovePreviousAndNextLocation,
+  SortableTreeWithoutDndContext as SortableTree
+} from 'react-sortable-tree'
 import {StoredTreeItem, TreeInputOptions} from '../types'
 import getCommonTreeProps from '../utils/getCommonTreeProps'
 import getTreeHeight from '../utils/getTreeHeight'
@@ -12,7 +19,9 @@ import useLocalTree from '../hooks/useLocalTree'
 import {TreeOperationsContext} from '../hooks/useTreeOperations'
 import useTreeOperationsProvider from '../hooks/useTreeOperationsProvider'
 import DocumentInNode from './DocumentInNode'
-import TreeEditorErrorBoundary from './TreeEditorErrorBoundary'
+import {DndProvider} from 'react-dnd'
+import {TreeEditorErrorBoundary} from './TreeEditorErrorBoundary'
+import {suppressedDnDManager} from './SuppressedDnDManager'
 
 /**
  * The loaded tree users interact with
@@ -35,87 +44,111 @@ const TreeEditor: React.FC<{
     localTree
   })
 
+  const doNothingOnChange = useCallback(() => {
+    // Do nothing. onMoveNode will do all the work
+  }, [])
+
+  const canDrop = useCanDrop()
+  const onMoveNode = useCallback(
+    (data: NodeData & FullTree & OnMovePreviousAndNextLocation) =>
+      operations.handleMovedNode(data as unknown as HandleMovedNodeData),
+    [operations]
+  )
+  const treeProps = useMemo(
+    () =>
+      getCommonTreeProps({
+        placeholder: {
+          title: 'Add items from the list below'
+        }
+      }),
+    []
+  )
+
   return (
     <TreeEditorErrorBoundary>
-      <TreeOperationsContext.Provider value={{...operations, allItemsStatus}}>
-        <Stack space={4} paddingTop={4}>
-          <Card
-            style={{minHeight: getTreeHeight(localTree)}}
-            // Only include borderBottom if there's something to show in unadded items
-            borderBottom={allItemsStatus !== 'success' || unaddedItems?.length > 0}
-          >
-            <SortableTree
-              maxDepth={props.options.maxDepth}
-              onChange={() => {
-                // Do nothing. onMoveNode will do all the work
-              }}
-              onVisibilityToggle={handleVisibilityToggle}
-              onMoveNode={(data) =>
-                operations.handleMovedNode(data as unknown as HandleMovedNodeData)
-              }
-              treeData={localTree}
-              {...getCommonTreeProps({
-                placeholder: {
-                  title: 'Add items from the list below'
-                }
-              })}
-            />
-          </Card>
+      <DndProvider manager={suppressedDnDManager}>
+        <TreeOperationsContext.Provider value={{...operations, allItemsStatus}}>
+          <Stack space={4} paddingTop={4}>
+            <Card
+              style={{minHeight: getTreeHeight(localTree)}}
+              // Only include borderBottom if there's something to show in unadded items
+              borderBottom={allItemsStatus !== 'success' || unaddedItems?.length > 0}
+            >
+              <SortableTree
+                maxDepth={props.options.maxDepth}
+                onChange={doNothingOnChange}
+                onVisibilityToggle={handleVisibilityToggle}
+                canDrop={canDrop}
+                onMoveNode={onMoveNode}
+                treeData={localTree}
+                {...treeProps}
+              />
+            </Card>
 
-          {allItemsStatus === 'success' && unaddedItems?.length > 0 && (
-            <Stack space={1} paddingX={2} paddingTop={3}>
-              <Stack space={2} paddingX={2} paddingBottom={3}>
-                <Text size={2} as="h2" weight="semibold">
-                  Add more items
-                </Text>
-                <Text size={1} muted>
-                  Only published documents are shown.
-                </Text>
+            {allItemsStatus === 'success' && unaddedItems?.length > 0 && (
+              <Stack space={1} paddingX={2} paddingTop={3}>
+                <Stack space={2} paddingX={2} paddingBottom={3}>
+                  <Text size={2} as="h2" weight="semibold">
+                    Add more items
+                  </Text>
+                  <Text size={1} muted>
+                    Only published documents are shown.
+                  </Text>
+                </Stack>
+                {unaddedItems.map((item) => (
+                  <DocumentInNode
+                    key={item.publishedId || item.draftId}
+                    item={item}
+                    action={
+                      <Tooltip
+                        portal
+                        placement="left"
+                        content={
+                          <Box padding={2}>
+                            <Text size={1}>Add to list</Text>
+                          </Box>
+                        }
+                      >
+                        <Button
+                          onClick={() => {
+                            operations.addItem(item)
+                          }}
+                          mode="bleed"
+                          icon={AddCircleIcon}
+                          style={{cursor: 'pointer'}}
+                        />
+                      </Tooltip>
+                    }
+                  />
+                ))}
               </Stack>
-              {unaddedItems.map((item) => (
-                <DocumentInNode
-                  key={item.publishedId || item.draftId}
-                  item={item}
-                  action={
-                    <Tooltip
-                      portal
-                      placement="left"
-                      content={
-                        <Box padding={2}>
-                          <Text size={1}>Add to list</Text>
-                        </Box>
-                      }
-                    >
-                      <Button
-                        onClick={() => {
-                          operations.addItem(item)
-                        }}
-                        mode="bleed"
-                        icon={AddCircleIcon}
-                        style={{cursor: 'pointer'}}
-                      />
-                    </Tooltip>
-                  }
-                />
-              ))}
-            </Stack>
-          )}
-          {allItemsStatus === 'loading' && (
-            <Flex padding={4} align={'center'} justify={'center'}>
-              <Spinner size={3} muted />
-            </Flex>
-          )}
-          {allItemsStatus === 'error' && (
-            <Flex padding={4} align={'center'} justify={'center'}>
-              <Text size={2} weight="semibold">
-                Something went wrong when loading documents
-              </Text>
-            </Flex>
-          )}
-        </Stack>
-      </TreeOperationsContext.Provider>
+            )}
+            {allItemsStatus === 'loading' && (
+              <Flex padding={4} align={'center'} justify={'center'}>
+                <Spinner size={3} muted />
+              </Flex>
+            )}
+            {allItemsStatus === 'error' && (
+              <Flex padding={4} align={'center'} justify={'center'}>
+                <Text size={2} weight="semibold">
+                  Something went wrong when loading documents
+                </Text>
+              </Flex>
+            )}
+          </Stack>
+        </TreeOperationsContext.Provider>
+      </DndProvider>
     </TreeEditorErrorBoundary>
   )
+}
+
+function useCanDrop() {
+  return useCallback(({nextPath, prevPath}: OnDragPreviousAndNextLocation & NodeData) => {
+    const insideItself =
+      nextPath.length >= prevPath.length &&
+      prevPath.every((pathIndex, index) => nextPath[index] === pathIndex)
+    return !insideItself
+  }, [])
 }
 
 export default TreeEditor

--- a/src/components/TreeEditorErrorBoundary.tsx
+++ b/src/components/TreeEditorErrorBoundary.tsx
@@ -1,40 +1,22 @@
-import {ErrorBoundary, ErrorBoundaryProps, useToast} from '@sanity/ui'
 import * as React from 'react'
 
-type BoundaryError = Parameters<ErrorBoundaryProps['onCatch']>[0]
-
-const DISPLAY_ERROR = false
-
-const ErrorToast: React.FC<{error?: BoundaryError}> = ({error}) => {
-  const {push} = useToast()
-
-  React.useEffect(() => {
-    if (error?.error && DISPLAY_ERROR) {
-      push({
-        title: error.error.name,
-        description: error.error.message,
-        closable: true,
-        status: 'error',
-        id: 'hierarchical-error'
-      })
-    }
-  }, [error])
-
-  return null
+/**
+ * react-sortable-tree emits a lot of random errors when dragging to invalid states,
+ * even when drag-targets are disabled.
+ *
+ * This boundary is a workaround so users are not pestered with error-toasts for things
+ * that have no functional impact.
+ *
+ * This boundry does NOT handle errors that happen in the React dnd
+ * event handlers, so there is addtional workarounds in the
+ * DnDManager.
+ *  */
+export class TreeEditorErrorBoundary extends React.Component {
+  // eslint-disable-next-line class-methods-use-this
+  componentDidCatch(error: Error) {
+    // do nothing
+  }
+  render() {
+    return this.props.children
+  }
 }
-
-const TreeEditorErrorBoundary: React.FC = (props) => {
-  const [exception, setException] = React.useState<BoundaryError | undefined>(undefined)
-  return (
-    <ErrorBoundary
-      onCatch={(newException) => {
-        setException(newException)
-      }}
-    >
-      <ErrorToast error={exception} />
-      {props.children}
-    </ErrorBoundary>
-  )
-}
-
-export default TreeEditorErrorBoundary

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,8 +82,10 @@ export interface TreeInputOptions {
   /**
    * Schema type for your hierarchical documents.
    * Refer to documentation on how to provide these schemas in your studio.
+   *
+   * Defautlt: 'hierarchy.tree' - this schema is bundled with the plugin
    */
-  documentType: string
+  documentType?: string
 }
 
 export interface TreeFieldSchema

--- a/src/utils/gradientPatchAdapter.ts
+++ b/src/utils/gradientPatchAdapter.ts
@@ -1,5 +1,4 @@
 // Adapted from @sanity/form-builder/src/sanity/utils/gradientPatchAdapter.ts
-import assert from 'assert'
 import {arrayToJSONMatchPath} from '@sanity/mutator'
 
 type Patch = Record<string, any>
@@ -28,7 +27,9 @@ function toGradientPatch(patch: Patch): GradientPatch {
     }
   }
 
-  assert(patch.type, `Missing patch type in patch ${JSON.stringify(patch)}`)
+  if (!patch.type) {
+    throw new Error(`Missing patch type in patch ${JSON.stringify(patch)}`)
+  }
   if (matchPath) {
     return {
       [patch.type]: {


### PR DESCRIPTION
## Reviewer questions

I just commited this as patch-changes, but since the types will now "work" this _could_ break existing integrations.
Should this be a breaking change?


## Reported error

Hierarchical input: "Cannot have two HTML 5 backends"
Knut reported errors with the plugin.

"Upgraded to 1.0 and got an error when I try to drag items. Seems somewhat severe? (I don’t have time to troubleshoot it rn). Studio is fully up to date."


## Solution
We must use react-sortable-tree without a managed react-dnd context, and provided it ourself.

Additionally we have to monkeypatchadjust the DragDropMonitor in HTML5Backend to suppress unwanted errors that have no functional impact on the hierarchy, but that leads to annoying error-toasts from Sanity Studio

## Reproduction steps
* Add two hierarchy entries to the structure
* Navigate between the two list items
* Dragging now emits HTML5 backend errors

## Other issues with the plugin
Discovered during work with this issue:

* checkout -> npm install -> npm build fails: latest commit does not compile
* types.d.ts file is imported in createDeskhierarchy. This file is not bundled, so studio get type-errors. It should be renamed to types.ts.
* documentType has a default but is typed as required.
 * Dragging an item into itself emits a error toast and emits error in console. We should just ignore these drag events.
* Sometimes get :"react_devtools_backend.js:3973 Invariant Violation: Expected to find a valid target." errors. Source code from reactdnd indicated that "The invariant message will be stripped in production", so may not be critical, as it does not impact functionality in any other way. Seems to be related with dragging items "quickly".

## Regression tests

### Check that the reported error is gone

* Add createDeskHierarchy into any StructureBuilder items list twice ([example](https://github.com/sanity-io/structured-content-2022/blob/main/studio/src/deskStructure.ts#L178))
* Click the first hierarchy, add some stuff, drag and drop
* Click the second hierarchy, click back to the first
* Drag and drop should NOT emit a bunch of error-toasts and/or crash the hierarchy input

### Check that the other discovered errors are resolved

* In a hierarchy, on a node with at least one child
* Drag the parent into itself so it show a red drag target. No error toast should appear after dropping.
* Finally, drag items quickly up and down. No error toasts should appear.

### Check typings
* createDeskHierarchy should not emit Type-errors when providing a documentId. documentType should be optional.