### PR TITLE
docs: add deprecation message to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## ⚠️ This plugin is DEPRECATED
+
+We regret to inform you that this project is no longer maintained and is deprecated.
+
+---
+
 # sanity-plugin-hierarchical-document-list
 
 Plugin for visually organizing documents as hierarchies in the [Sanity studio](https://www.sanity.io/docs/sanity-studio). Applications include:


### PR DESCRIPTION
Add a deprecation notice in the top of the README.md:

```md
## ⚠️ This plugin is DEPRECATED

We regret to inform you that this project is no longer maintained and is deprecated.

---
```